### PR TITLE
Add button widget support

### DIFF
--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,6 +1,6 @@
 use bevy::prelude::*;
 use bevy_widgets::{
-    widget::button::{ButtonColor, ButtonTheme},
+    widget::button::{ButtonColor, ButtonTheme, TriggerPolicy},
     WidgetPlugin, theme::WidgetTheme, create_text_button, create_h1, create_p, create_icon_button, create_label_button,
 };
 use material_icons::Icon;
@@ -113,9 +113,9 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                     ..default()
                 }).with_children(| example_showcase | {
 
-                    create_text_button(example_showcase, &theme, "Open Inventory");
-                    create_icon_button(example_showcase, &theme, Icon::Menu);
-                    create_label_button(example_showcase, &theme, Icon::Send, "Send");
+                    create_text_button(example_showcase, &theme, "Open Inventory", true, TriggerPolicy::OnRelease);
+                    create_icon_button(example_showcase, &theme, Icon::Menu, true, TriggerPolicy::OnRelease);
+                    create_label_button(example_showcase, &theme, Icon::Send, "Send", true, TriggerPolicy::OnRelease);
                 });
 
 
@@ -142,8 +142,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
 
                     // Spawn text-buttons
                     for text in ["Ok", "Submit", "Restart Game"] {
-                        // TODO: These should be disabled
-                        create_text_button(example_showcase, &theme, text);
+                        create_text_button(example_showcase, &theme, text, false, TriggerPolicy::OnRelease);
                     }
                 });
 
@@ -165,10 +164,9 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                     color: COLOR_CONTENT_EXAMPLE.into(),
                     ..default()
                 }).with_children(| example_showcase | {
-                    // TODO: These buttons should have OnPress Trigger
-                    create_text_button(example_showcase, &theme, "Ok");
-                    create_text_button(example_showcase, &theme, "Ok");
-                    create_label_button(example_showcase, &theme, Icon::Wifi, "Enable Wifi");
+                    create_text_button(example_showcase, &theme, "Ok", true, TriggerPolicy::OnPress);
+                    create_text_button(example_showcase, &theme, "Ok", true, TriggerPolicy::OnPress);
+                    create_label_button(example_showcase, &theme, Icon::Wifi, "Enable Wifi", true, TriggerPolicy::OnPress);
 
                 });
 
@@ -192,7 +190,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
 
                     // Spawn icon-buttons
                     for icon in [Icon::Wifi, Icon::Subtitles, Icon::Delete, Icon::Add, Icon::Home] {
-                        create_icon_button(example_showcase, &theme, icon);
+                        create_icon_button(example_showcase, &theme, icon, true, TriggerPolicy::OnRelease);
                     }
                 });
 
@@ -222,7 +220,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         (Icon::Add, "Add item"), 
                         (Icon::Home, "Home")
                     ] {
-                        create_label_button(example_showcase, &theme, icon, text);
+                        create_label_button(example_showcase, &theme, icon, text,  true, TriggerPolicy::OnRelease);
                     }
                 });
             });

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,0 +1,591 @@
+use bevy::prelude::*;
+use bevy_widgets::{
+    widget::button::{ButtonColor, ButtonTheme, ButtonWidgetBundle, TriggerPolicy},
+    WidgetPlugin,
+};
+use material_icons::Icon;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(WidgetPlugin)
+        .add_startup_system(setup_camera)
+        .add_startup_system(setup_page)
+        .run();
+}
+
+const COLOR_BACKGROUND: Color = Color::rgb(0.047, 0.109, 0.172);
+const COLOR_CONTENT_BACKGROUND: Color = Color::rgb(0.065, 0.127, 0.195);
+const COLOR_CONTENT_EXAMPLE: Color = Color::rgb(0.055, 0.12, 0.19);
+
+const PRIMARY: Color = Color::rgb(0.2274, 0.2, 0.2078);
+// const COLOR_CONTENT_BACKGROUND: Color = Color::hsl(224, 15, 39);
+const H1_FONT: &str = "fonts/Roboto/Roboto-Bold.ttf";
+const H1_FONT_SIZE: f32 = 30.0;
+const COLOR_TEXT: Color = Color::rgb(0.905, 0.921, 0.941);
+
+const TEXT_FONT: &str = "fonts/Roboto/Roboto-Regular.ttf";
+const TEXT_FONT_SIZE: f32 = 18.0;
+const BUTTON_FONT_SIZE: f32 = 20.0;
+
+const MATERIAL_FONT: &str = "fonts/MaterialIcons-Regular.ttf";
+
+const BUTTON_THEME: ButtonTheme = ButtonTheme {
+    background_enabled: ButtonColor {
+        pressed: Color::rgb(0.7, 0.7, 0.7),
+        released: Color::rgb(0.6, 0.6, 0.6),
+        hovered: Color::GRAY,
+        default: Color::DARK_GRAY,
+    },
+    background_disabled: ButtonColor {
+        pressed: Color::rgb(0.16, 0.16, 0.16),
+        released: Color::rgb(0.16, 0.16, 0.16),
+        hovered: Color::rgb(0.16, 0.16, 0.16),
+        default: Color::rgb(0.15, 0.15, 0.15),
+    },
+    foreground_enabled: ButtonColor {
+        pressed: Color::BLUE,
+        released: Color::rgb(0.905, 0.921, 0.941),
+        hovered: Color::rgb(0.905, 0.921, 0.941),
+        default: Color::rgb(0.905, 0.921, 0.941),
+    },
+    foreground_disabled: ButtonColor {
+        pressed: Color::rgb(0.35, 0.35, 0.35),
+        released: Color::rgb(0.35, 0.35, 0.35),
+        hovered: Color::rgb(0.35, 0.35, 0.35),
+        default: Color::rgb(0.35, 0.35, 0.35),
+    },
+};
+
+/// Camera
+fn setup_camera(mut cmd: Commands) {
+    cmd.spawn_bundle(Camera2dBundle::default());
+}
+
+// Button can be interacted with
+// It has some content
+// That content is either an icon, some text or both
+fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
+    // root node
+    cmd.spawn_bundle(NodeBundle {
+            style: Style {
+                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                justify_content: JustifyContent::Center,
+                flex_direction: FlexDirection::Row,
+                ..default()
+            },
+            color: COLOR_BACKGROUND.into(),
+            ..default()
+        }).with_children(| root| {
+            // Content container
+            root.spawn_bundle(NodeBundle {
+                style: Style {
+                    size: Size::new(Val::Auto, Val::Percent(100.0)),
+                    min_size: Size::new(Val::Px(800.0), Val::Auto),
+                    padding: UiRect::all(Val::Px(30.0)),
+                    flex_direction: FlexDirection::ColumnReverse,
+                    justify_content: JustifyContent::FlexStart,
+                    align_items: AlignItems::FlexStart,
+                    ..default()
+                },
+                color: COLOR_BACKGROUND.into(),
+                ..default()
+            }).with_children(| content | {
+                // Title text
+                content.spawn_bundle(TextBundle::from_section(
+                    "Buttons", 
+                    TextStyle {
+                        font: asset_server.load(H1_FONT).into(),
+                        font_size: H1_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ).with_style(Style {
+                     margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
+                    ..default()
+                }));
+                // Paragraph
+                content.spawn_bundle(TextBundle::from_section(
+                    "Buttons are used to trigger actions. They can be clicked and hovered.",
+                    TextStyle {
+                        font: asset_server.load(TEXT_FONT).into(),
+                        font_size: TEXT_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ));
+                
+                // Example Showcase
+                content.spawn_bundle(NodeBundle {
+                    style: Style {
+                        size: Size::new(Val::Percent(100.0), Val::Px(80.0)),
+                        margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(10.0), Val::Px(10.0)),
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        
+                        ..default()
+                    },
+                    color: COLOR_CONTENT_EXAMPLE.into(),
+                    ..default()
+                }).with_children(| example_showcase | {
+                    // 1. Button without content
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    )).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            "Ok",
+                            TextStyle {
+                                font: asset_server.load(TEXT_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ));
+                    });
+
+                    // 2. Button with text
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    )).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            "Submit",
+                            TextStyle {
+                                font: asset_server.load(TEXT_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ));
+                    });
+
+                    // 3. Button with icon and text
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::FlexStart,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    )).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            Icon::Delete.to_string(),
+                            TextStyle {
+                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ).with_style(Style {
+                            margin: UiRect::all(Val::Px(10.0)),
+                            ..default()
+                        }));
+                        button.spawn_bundle(TextBundle::from_section(
+                            "Delete",
+                            TextStyle {
+                                font: asset_server.load(TEXT_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ));
+                    });
+                });
+
+                // Title text
+                content.spawn_bundle(TextBundle::from_section(
+                    "Disabled Buttons", 
+                    TextStyle {
+                        font: asset_server.load(H1_FONT).into(),
+                        font_size: H1_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ).with_style(Style {
+                    margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
+                   ..default()
+               }));
+                // Paragraph
+                content.spawn_bundle(TextBundle::from_section(
+                    "Buttons can be either enabled or disabled. \
+                            When they are disabled, they should look the part, \
+                            and not be able to be triggered by the user.",
+                    TextStyle {
+                        font: asset_server.load(TEXT_FONT).into(),
+                        font_size: TEXT_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ));
+                
+                // Example Showcase
+                content.spawn_bundle(NodeBundle {
+                    style: Style {
+                        size: Size::new(Val::Percent(100.0), Val::Px(80.0)),
+                        margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(10.0), Val::Px(10.0)),
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        
+                        ..default()
+                    },
+                    color: COLOR_CONTENT_EXAMPLE.into(),
+                    ..default()
+                }).with_children(| example_showcase | {
+                    // 1. Button without content
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    ).with_enabled(false)
+                    ).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            "Ok",
+                            TextStyle {
+                                font: asset_server.load(TEXT_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ));
+                    });
+
+                    // 2. Button with text
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    ).with_enabled(false)
+                    ).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            "Submit",
+                            TextStyle {
+                                font: asset_server.load(TEXT_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ));
+                    });
+
+                    // 3. Button with icon and text
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::FlexStart,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    ).with_enabled(false)
+                    ).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            Icon::Wifi.to_string(),
+                            TextStyle {
+                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ).with_style(Style {
+                            margin: UiRect::all(Val::Px(10.0)),
+                            ..default()
+                        }));
+                        button.spawn_bundle(TextBundle::from_section(
+                            "Enable Wifi",
+                            TextStyle {
+                                font: asset_server.load(TEXT_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ));
+                    });
+                });
+
+
+                // Title text
+                content.spawn_bundle(TextBundle::from_section(
+                    "Trigger Policy", 
+                    TextStyle {
+                        font: asset_server.load(H1_FONT).into(),
+                        font_size: H1_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ).with_style(Style {
+                    margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
+                   ..default()
+               }));
+                // Paragraph
+                content.spawn_bundle(TextBundle::from_section(
+                    "Buttons are triggered on release by default. By setting the trigger-policy you can change the button to trigger on press instead.",
+                    TextStyle {
+                        font: asset_server.load(TEXT_FONT).into(),
+                        font_size: TEXT_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ));
+                
+                // Example Showcase
+                content.spawn_bundle(NodeBundle {
+                    style: Style {
+                        size: Size::new(Val::Percent(100.0), Val::Px(80.0)),
+                        margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(10.0), Val::Px(10.0)),
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        
+                        ..default()
+                    },
+                    color: COLOR_CONTENT_EXAMPLE.into(),
+                    ..default()
+                }).with_children(| example_showcase | {
+                    // 1. Button without content
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    ).with_policy(TriggerPolicy::OnPress)
+                    ).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            "Ok",
+                            TextStyle {
+                                font: asset_server.load(TEXT_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ));
+                    });
+
+                    // 2. Button with text
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    ).with_policy(TriggerPolicy::OnPress)
+                    ).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            "Submit",
+                            TextStyle {
+                                font: asset_server.load(TEXT_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ));
+                    });
+
+                    // 3. Button with icon and text
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            align_items: AlignItems::Center,
+                            justify_content: JustifyContent::FlexStart,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    ).with_policy(TriggerPolicy::OnPress)
+                    ).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            Icon::Wifi.to_string(),
+                            TextStyle {
+                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ).with_style(Style {
+                            margin: UiRect::all(Val::Px(10.0)),
+                            ..default()
+                        }));
+                        button.spawn_bundle(TextBundle::from_section(
+                            "Enable Wifi",
+                            TextStyle {
+                                font: asset_server.load(TEXT_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            }
+                        ));
+                    });
+                });
+
+
+                // Title text
+                content.spawn_bundle(TextBundle::from_section(
+                    "Icon Buttons", 
+                    TextStyle {
+                        font: asset_server.load(H1_FONT).into(),
+                        font_size: H1_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ).with_style(Style {
+                    margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
+                   ..default()
+               }));
+                // Paragraph
+                content.spawn_bundle(TextBundle::from_section(
+                    "Some buttons only need icon.",
+                    TextStyle {
+                        font: asset_server.load(TEXT_FONT).into(),
+                        font_size: TEXT_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ));
+                
+                // Example Showcase
+                content.spawn_bundle(NodeBundle {
+                    style: Style {
+                        size: Size::new(Val::Percent(100.0), Val::Px(80.0)),
+                        margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(10.0), Val::Px(10.0)),
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        
+                        ..default()
+                    },
+                    color: COLOR_CONTENT_EXAMPLE.into(),
+                    ..default()
+                }).with_children(| example_showcase | {
+                    // 1. Icon button
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    )).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            Icon::Wifi.to_string(),
+                            TextStyle {
+                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            })
+                        );
+                    });
+
+                    // 2. Icon button
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    )).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            Icon::Subtitles.to_string(),
+                            TextStyle {
+                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            })
+                        );
+                    });
+
+                    // 3. Icon button
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    )).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            Icon::Delete.to_string(),
+                            TextStyle {
+                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            })
+                        );
+                    });
+
+                    // 3. Icon button
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            ..default()
+                        }, 
+                        BUTTON_THEME
+                    )).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            Icon::AlarmAdd.to_string(),
+                            TextStyle {
+                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            })
+                        );
+                    });
+
+                    // 3. Icon button
+                    example_showcase.spawn_bundle(
+                        ButtonWidgetBundle::new(Style {
+                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
+                            margin: UiRect::all(Val::Px(10.0)),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            ..default()
+                        },
+                        BUTTON_THEME
+                    )).with_children(| button | {
+                        button.spawn_bundle(TextBundle::from_section(
+                            Icon::Camera.to_string(),
+                            TextStyle {
+                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font_size: BUTTON_FONT_SIZE,
+                                color: COLOR_TEXT,
+                            })
+                        );
+                    });
+                });
+
+            });
+        });
+}
+
+// Handling clicks
+// Upload file button
+// Button with icon and label
+
+// All buttons should showcase
+// Hover visual behaviour
+// Button click visuals
+// Button disabled visuals
+//

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -121,7 +121,6 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         flex_direction: FlexDirection::Row,
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
-                        
                         ..default()
                     },
                     color: COLOR_CONTENT_EXAMPLE.into(),
@@ -139,7 +138,6 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 create_p(content, &theme, "Buttons can be either enabled or disabled. \
                 Disabled buttons should not be triggered by the user. \
                 Buttons should clearly show when they are disabled by changing colors.");
-                
                 // Example Showcase
                 content.spawn_bundle(NodeBundle {
                     style: Style {
@@ -148,7 +146,6 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         flex_direction: FlexDirection::Row,
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
-                        
                         ..default()
                     },
                     color: COLOR_CONTENT_EXAMPLE.into(),
@@ -164,7 +161,6 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 create_h1(content, &theme, "Trigger Policy");
                 create_p(content, &theme, "Buttons are triggered on release by default. \
                 By setting the trigger-policy you can change the button to trigger on press instead.");
-                
                 // Example Showcase
                 content.spawn_bundle(NodeBundle {
                     style: Style {
@@ -173,7 +169,6 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         flex_direction: FlexDirection::Row,
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
-                        
                         ..default()
                     },
                     color: COLOR_CONTENT_EXAMPLE.into(),
@@ -219,7 +214,6 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         flex_direction: FlexDirection::Row,
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
-                        
                         ..default()
                     },
                     color: COLOR_CONTENT_EXAMPLE.into(),

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,7 +1,7 @@
-use bevy::{prelude::*, ecs::system::Resource, reflect::erased_serde::private::serde::__private::de};
+use bevy::prelude::*;
 use bevy_widgets::{
-    widget::button::{ButtonColor, ButtonTheme, ButtonWidgetBundle, TriggerPolicy},
-    WidgetPlugin,
+    widget::button::{ButtonColor, ButtonTheme},
+    WidgetPlugin, theme::WidgetTheme, create_text_button, create_h1, create_p, create_icon_button, create_label_button,
 };
 use material_icons::Icon;
 
@@ -19,56 +19,36 @@ fn main() {
 // TODO: Show that clicking buttons actually change something
 
 const COLOR_BACKGROUND: Color = Color::rgb(0.047, 0.109, 0.172);
-const COLOR_CONTENT_BACKGROUND: Color = Color::rgb(0.065, 0.127, 0.195);
 const COLOR_CONTENT_EXAMPLE: Color = Color::rgb(0.055, 0.12, 0.19);
-
-const PRIMARY: Color = Color::rgb(0.2274, 0.2, 0.2078);
-// const COLOR_CONTENT_BACKGROUND: Color = Color::hsl(224, 15, 39);
-const H1_FONT_SIZE: f32 = 30.0;
 const COLOR_TEXT: Color = Color::rgb(0.905, 0.921, 0.941);
-
 const H1_FONT: &str = "fonts/Roboto/Roboto-Bold.ttf";
 const TEXT_FONT: &str = "fonts/Roboto/Roboto-Regular.ttf";
+const WIDGET_FONT: &str = "fonts/Roboto/Roboto-Regular.ttf";
 const MATERIAL_FONT: &str = "fonts/MaterialIcons-Regular.ttf";
 
 
+const H1_FONT_SIZE: f32 = 30.0;
 const TEXT_FONT_SIZE: f32 = 18.0;
 const BUTTON_FONT_SIZE: f32 = 20.0;
-const ICON_FONT_SIZE: f32 = 25.0;
+const ICON_FONT_SIZE: f32 = 20.0;
 
-
+// TODO: Button should not change on hover
 const BUTTON_THEME: ButtonTheme = ButtonTheme {
-    background_enabled: ButtonColor {
+    background: ButtonColor {
         pressed: Color::rgb(0.7, 0.7, 0.7),
         released: Color::rgb(0.6, 0.6, 0.6),
-        hovered: Color::GRAY,
-        default: Color::DARK_GRAY,
+        hovered: Color::rgb(0.5, 0.5, 0.5),
+        default: Color::rgb(0.25, 0.25, 0.25),
+        disabled: Color::rgb(0.1, 0.1, 0.1),
     },
-    background_disabled: ButtonColor {
-        pressed: Color::rgb(0.16, 0.16, 0.16),
-        released: Color::rgb(0.16, 0.16, 0.16),
-        hovered: Color::rgb(0.16, 0.16, 0.16),
-        default: Color::rgb(0.15, 0.15, 0.15),
-    },
-    foreground_enabled: ButtonColor {
-        pressed: Color::BLUE,
+    foreground: ButtonColor {
+        pressed: Color::rgb(0.9, 0.5, 0.1),
         released: Color::rgb(0.905, 0.921, 0.941),
         hovered: Color::rgb(0.905, 0.921, 0.941),
         default: Color::rgb(0.905, 0.921, 0.941),
-    },
-    foreground_disabled: ButtonColor {
-        pressed: Color::rgb(0.35, 0.35, 0.35),
-        released: Color::rgb(0.35, 0.35, 0.35),
-        hovered: Color::rgb(0.35, 0.35, 0.35),
-        default: Color::rgb(0.35, 0.35, 0.35),
+        disabled: Color::rgb(0.35, 0.35, 0.35),
     },
 };
-
-struct Fonts {
-    h1: Handle<Font>,
-    p: Handle<Font>,
-    icon: Handle<Font>
-}
 
 /// Camera
 fn setup_camera(mut cmd: Commands) {
@@ -77,11 +57,14 @@ fn setup_camera(mut cmd: Commands) {
 
 
 fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
-    // Fonts
-    let fonts = Fonts {
-        h1: asset_server.load(H1_FONT),
-        p: asset_server.load(TEXT_FONT),
-        icon: asset_server.load(MATERIAL_FONT),
+
+    // Setup theme used for these widgets
+    let theme = WidgetTheme {
+        h1: TextStyle { font: asset_server.load(H1_FONT), font_size: H1_FONT_SIZE, color: COLOR_TEXT },
+        p: TextStyle { font: asset_server.load(TEXT_FONT), font_size: TEXT_FONT_SIZE, color: COLOR_TEXT },
+        icon: TextStyle { font: asset_server.load(MATERIAL_FONT), font_size: ICON_FONT_SIZE, color: COLOR_TEXT },
+        widget: TextStyle { font: asset_server.load(WIDGET_FONT), font_size: BUTTON_FONT_SIZE, color: COLOR_TEXT },
+        button_theme: BUTTON_THEME,
     };
 
     // root node
@@ -110,29 +93,37 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 color: COLOR_BACKGROUND.into(),
                 ..default()
             }).with_children(| content | {
-                // Title text
-                content.spawn_bundle(TextBundle::from_section(
-                    "Buttons", 
-                    TextStyle {
-                        font: fonts.h1.clone(),
-                        font_size: H1_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ).with_style(Style {
-                     margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
+
+                create_h1(content, &theme, "Buttons");
+                create_p(content, &theme, "Buttons are used to trigger actions. \
+                They can be hovered and clicked. The most basic button is the text button");
+
+                // Example Showcase
+                content.spawn_bundle(NodeBundle {
+                    style: Style {
+                        size: Size::new(Val::Percent(100.0), Val::Px(80.0)),
+                        margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(10.0), Val::Px(10.0)),
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        
+                        ..default()
+                    },
+                    color: COLOR_CONTENT_EXAMPLE.into(),
                     ..default()
-                }));
-                // Paragraph
-                content.spawn_bundle(TextBundle::from_section(
-                    "Buttons are used to trigger actions. \
-                    They can be hovered and clicked. \
-                    The most basic button is the text button",
-                    TextStyle {
-                        font: fonts.p.clone(),
-                        font_size: TEXT_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ));
+                }).with_children(| example_showcase | {
+
+                    create_text_button(example_showcase, &theme, "Open Inventory");
+                    create_icon_button(example_showcase, &theme, Icon::Menu);
+                    create_label_button(example_showcase, &theme, Icon::Send, "Send");
+                });
+
+
+                create_h1(content, &theme, "Disabled Buttons");
+
+                create_p(content, &theme, "Buttons can be either enabled or disabled. \
+                Disabled buttons should not be triggered by the user. \
+                Buttons should clearly show when they are disabled by changing colors.");
                 
                 // Example Showcase
                 content.spawn_bundle(NodeBundle {
@@ -151,52 +142,14 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
 
                     // Spawn text-buttons
                     for text in ["Ok", "Submit", "Restart Game"] {
-                        example_showcase.spawn_bundle(
-                            ButtonWidgetBundle::new(Style {
-                                size: Size::new(Val::Auto, Val::Auto),
-                                padding: UiRect::new(Val::Px(25.0), Val::Px(25.0), Val::Px(10.0), Val::Px(10.0)),
-                                margin: UiRect::all(Val::Px(10.0)),
-                                align_items: AlignItems::Center,
-                                justify_content: JustifyContent::Center,
-                                ..default()
-                            }, 
-                            BUTTON_THEME
-                        )).with_children(| button | {
-                            button.spawn_bundle(TextBundle::from_section(
-                                text,
-                                TextStyle {
-                                    font: fonts.p.clone(),
-                                    font_size: BUTTON_FONT_SIZE,
-                                    color: COLOR_TEXT,
-                                }
-                            ));
-                        });
+                        // TODO: These should be disabled
+                        create_text_button(example_showcase, &theme, text);
                     }
                 });
 
-                // Title text
-                content.spawn_bundle(TextBundle::from_section(
-                    "Disabled Buttons", 
-                    TextStyle {
-                        font: fonts.h1.clone(),
-                        font_size: H1_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ).with_style(Style {
-                    margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
-                   ..default()
-               }));
-                // Paragraph
-                content.spawn_bundle(TextBundle::from_section(
-                    "Buttons can be either enabled or disabled. \
-                            Disabled buttons should not be triggered by the user. \
-                            Buttons should clearly show when they are disabled by changing colors.",
-                    TextStyle {
-                        font: fonts.p.clone(),
-                        font_size: TEXT_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ));
+                create_h1(content, &theme, "Trigger Policy");
+                create_p(content, &theme, "Buttons are triggered on release by default. \
+                By setting the trigger-policy you can change the button to trigger on press instead.");
                 
                 // Example Showcase
                 content.spawn_bundle(NodeBundle {
@@ -212,168 +165,16 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                     color: COLOR_CONTENT_EXAMPLE.into(),
                     ..default()
                 }).with_children(| example_showcase | {
+                    // TODO: These buttons should have OnPress Trigger
+                    create_text_button(example_showcase, &theme, "Ok");
+                    create_text_button(example_showcase, &theme, "Ok");
+                    create_label_button(example_showcase, &theme, Icon::Wifi, "Enable Wifi");
 
-                    // Spawn text-buttons
-                    for text in ["Ok", "Submit", "Restart Game"] {
-                        example_showcase.spawn_bundle(
-                            ButtonWidgetBundle::new(Style {
-                                size: Size::new(Val::Auto, Val::Auto),
-                                padding: UiRect::new(Val::Px(25.0), Val::Px(25.0), Val::Px(10.0), Val::Px(10.0)),
-                                margin: UiRect::all(Val::Px(10.0)),
-                                align_items: AlignItems::Center,
-                                justify_content: JustifyContent::Center,
-                                ..default()
-                            }, 
-                            BUTTON_THEME
-                        ).with_enabled(false)
-                        ).with_children(| button | {
-                            button.spawn_bundle(TextBundle::from_section(
-                                text,
-                                TextStyle {
-                                    font: fonts.p.clone(),
-                                    font_size: BUTTON_FONT_SIZE,
-                                    color: COLOR_TEXT,
-                                }
-                            ));
-                        });
-                    }
                 });
 
+                create_h1(content, &theme, "Icon Buttons");
+                create_p(content, &theme, "Some buttons only need icon.");
 
-                // Title text
-                content.spawn_bundle(TextBundle::from_section(
-                    "Trigger Policy", 
-                    TextStyle {
-                        font: fonts.h1.clone(),
-                        font_size: H1_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ).with_style(Style {
-                    margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
-                   ..default()
-               }));
-                // Paragraph
-                content.spawn_bundle(TextBundle::from_section(
-                    "Buttons are triggered on release by default. By setting the trigger-policy you can change the button to trigger on press instead.",
-                    TextStyle {
-                        font: fonts.p.clone(),
-                        font_size: TEXT_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ));
-                
-                // Example Showcase
-                content.spawn_bundle(NodeBundle {
-                    style: Style {
-                        size: Size::new(Val::Percent(100.0), Val::Px(80.0)),
-                        margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(10.0), Val::Px(10.0)),
-                        flex_direction: FlexDirection::Row,
-                        align_items: AlignItems::Center,
-                        justify_content: JustifyContent::Center,
-                        
-                        ..default()
-                    },
-                    color: COLOR_CONTENT_EXAMPLE.into(),
-                    ..default()
-                }).with_children(| example_showcase | {
-                    // 1. Button without content
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            align_items: AlignItems::Center,
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    ).with_policy(TriggerPolicy::OnPress)
-                    ).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            "Ok",
-                            TextStyle {
-                                font: fonts.p.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                    });
-
-                    // 2. Button with text
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            align_items: AlignItems::Center,
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    ).with_policy(TriggerPolicy::OnPress)
-                    ).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            "Submit",
-                            TextStyle {
-                                font: fonts.p.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                    });
-
-                    // 3. Button with icon and text
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            align_items: AlignItems::Center,
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    ).with_policy(TriggerPolicy::OnPress)
-                    ).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            Icon::Wifi.to_string(),
-                            TextStyle {
-                                font: fonts.icon.clone(),
-                                font_size: ICON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                        button.spawn_bundle(TextBundle::from_section(
-                            "Enable Wifi",
-                            TextStyle {
-                                font: fonts.p.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                    });
-                });
-
-
-                // Title text
-                content.spawn_bundle(TextBundle::from_section(
-                    "Icon Buttons", 
-                    TextStyle {
-                        font: fonts.h1.clone(),
-                        font_size: H1_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ).with_style(Style {
-                    margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
-                   ..default()
-               }));
-                // Paragraph
-                content.spawn_bundle(TextBundle::from_section(
-                    "Some buttons only need icon.",
-                    TextStyle {
-                        font: fonts.p.clone(),
-                        font_size: TEXT_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ));
-                
                 // Example Showcase
                 content.spawn_bundle(NodeBundle {
                     style: Style {
@@ -390,51 +191,14 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 }).with_children(| example_showcase | {
 
                     // Spawn icon-buttons
-                    for entry in [Icon::Wifi, Icon::Subtitles, Icon::Delete, Icon::Add, Icon::Home] {
-                        example_showcase.spawn_bundle(
-                            ButtonWidgetBundle::new(Style {
-                                size: Size::new(Val::Px(40.0), Val::Px(40.0)),
-                                margin: UiRect::all(Val::Px(10.0)),
-                                justify_content: JustifyContent::Center,
-                                align_items: AlignItems::Center,
-                                ..default()
-                            }, 
-                            BUTTON_THEME
-                        )).with_children(| button | {
-                            button.spawn_bundle(TextBundle::from_section(
-                                entry.to_string(),
-                                TextStyle {
-                                    font: fonts.icon.clone(),
-                                    font_size: ICON_FONT_SIZE,
-                                    color: COLOR_TEXT,
-                                })
-                            );
-                        });
+                    for icon in [Icon::Wifi, Icon::Subtitles, Icon::Delete, Icon::Add, Icon::Home] {
+                        create_icon_button(example_showcase, &theme, icon);
                     }
                 });
 
-                // Title text
-                content.spawn_bundle(TextBundle::from_section(
-                    "Icon and text buttons", 
-                    TextStyle {
-                        font: fonts.h1.clone(),
-                        font_size: H1_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ).with_style(Style {
-                    margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
-                   ..default()
-               }));
-                // Paragraph
-                content.spawn_bundle(TextBundle::from_section(
-                    "We can also create buttons that has both icons and text.",
-                    TextStyle {
-                        font: fonts.p.clone(),
-                        font_size: TEXT_FONT_SIZE,
-                        color: COLOR_TEXT,
-                    }
-                ));
-                
+                create_h1(content, &theme, "Icon and Text Buttons");
+                create_p(content, &theme, "We can also create buttons that has both icons and text.");
+
                 // Example Showcase
                 content.spawn_bundle(NodeBundle {
                     style: Style {
@@ -458,37 +222,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         (Icon::Add, "Add item"), 
                         (Icon::Home, "Home")
                     ] {
-                        example_showcase.spawn_bundle(
-                            ButtonWidgetBundle::new(Style {
-                                size: Size::new(Val::Auto, Val::Auto),
-                                padding: UiRect::new(Val::Px(15.0), Val::Px(15.0), Val::Px(10.0), Val::Px(10.0)),
-                                margin: UiRect::all(Val::Px(3.0)),
-                                align_items: AlignItems::Center,
-                                justify_content: JustifyContent::Center,
-                                ..default()
-                            }, 
-                            BUTTON_THEME
-                        )).with_children(| button | {
-                            button.spawn_bundle(TextBundle::from_section(
-                                icon.to_string(),
-                                TextStyle {
-                                    font: fonts.icon.clone(),
-                                    font_size: ICON_FONT_SIZE,
-                                    color: COLOR_TEXT,
-                                }
-                            ).with_style(Style {
-                                margin: UiRect::new(Val::Undefined, Val::Px(5.0), Val::Undefined, Val::Undefined),
-                                ..default()
-                            }));
-                            button.spawn_bundle(TextBundle::from_section(
-                                text,
-                                TextStyle {
-                                    font: fonts.p.clone(),
-                                    font_size: BUTTON_FONT_SIZE,
-                                    color: COLOR_TEXT,
-                                }
-                            ));
-                        });
+                        create_label_button(example_showcase, &theme, icon, text);
                     }
                 });
             });

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,7 +1,9 @@
 use bevy::prelude::*;
 use bevy_widgets::{
+    create_h1, create_icon_button, create_label_button, create_p, create_text_button,
+    theme::WidgetTheme,
     widget::button::{ButtonColor, ButtonTheme, TriggerPolicy},
-    WidgetPlugin, theme::WidgetTheme, create_text_button, create_h1, create_p, create_icon_button, create_label_button,
+    WidgetPlugin,
 };
 use material_icons::Icon;
 
@@ -25,7 +27,6 @@ const H1_FONT: &str = "fonts/Roboto/Roboto-Bold.ttf";
 const TEXT_FONT: &str = "fonts/Roboto/Roboto-Regular.ttf";
 const WIDGET_FONT: &str = "fonts/Roboto/Roboto-Regular.ttf";
 const MATERIAL_FONT: &str = "fonts/MaterialIcons-Regular.ttf";
-
 
 const H1_FONT_SIZE: f32 = 30.0;
 const TEXT_FONT_SIZE: f32 = 18.0;
@@ -55,15 +56,29 @@ fn setup_camera(mut cmd: Commands) {
     cmd.spawn_bundle(Camera2dBundle::default());
 }
 
-
 fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
-
     // Setup theme used for these widgets
     let theme = WidgetTheme {
-        h1: TextStyle { font: asset_server.load(H1_FONT), font_size: H1_FONT_SIZE, color: COLOR_TEXT },
-        p: TextStyle { font: asset_server.load(TEXT_FONT), font_size: TEXT_FONT_SIZE, color: COLOR_TEXT },
-        icon: TextStyle { font: asset_server.load(MATERIAL_FONT), font_size: ICON_FONT_SIZE, color: COLOR_TEXT },
-        widget: TextStyle { font: asset_server.load(WIDGET_FONT), font_size: BUTTON_FONT_SIZE, color: COLOR_TEXT },
+        h1: TextStyle {
+            font: asset_server.load(H1_FONT),
+            font_size: H1_FONT_SIZE,
+            color: COLOR_TEXT,
+        },
+        p: TextStyle {
+            font: asset_server.load(TEXT_FONT),
+            font_size: TEXT_FONT_SIZE,
+            color: COLOR_TEXT,
+        },
+        icon: TextStyle {
+            font: asset_server.load(MATERIAL_FONT),
+            font_size: ICON_FONT_SIZE,
+            color: COLOR_TEXT,
+        },
+        widget: TextStyle {
+            font: asset_server.load(WIDGET_FONT),
+            font_size: BUTTON_FONT_SIZE,
+            color: COLOR_TEXT,
+        },
         button_theme: BUTTON_THEME,
     };
 
@@ -181,7 +196,6 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         flex_direction: FlexDirection::Row,
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
-                        
                         ..default()
                     },
                     color: COLOR_CONTENT_EXAMPLE.into(),

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, ecs::system::Resource};
+use bevy::{prelude::*, ecs::system::Resource, reflect::erased_serde::private::serde::__private::de};
 use bevy_widgets::{
     widget::button::{ButtonColor, ButtonTheme, ButtonWidgetBundle, TriggerPolicy},
     WidgetPlugin,
@@ -13,6 +13,10 @@ fn main() {
         .add_startup_system(setup_page)
         .run();
 }
+
+// TODO: Show buttons with labels in different positions
+// TODO: Show buttons with different themes / styles
+// TODO: Show that clicking buttons actually change something
 
 const COLOR_BACKGROUND: Color = Color::rgb(0.047, 0.109, 0.172);
 const COLOR_CONTENT_BACKGROUND: Color = Color::rgb(0.065, 0.127, 0.195);
@@ -30,6 +34,7 @@ const MATERIAL_FONT: &str = "fonts/MaterialIcons-Regular.ttf";
 
 const TEXT_FONT_SIZE: f32 = 18.0;
 const BUTTON_FONT_SIZE: f32 = 20.0;
+const ICON_FONT_SIZE: f32 = 25.0;
 
 
 const BUTTON_THEME: ButtonTheme = ButtonTheme {
@@ -94,7 +99,8 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
             root.spawn_bundle(NodeBundle {
                 style: Style {
                     size: Size::new(Val::Auto, Val::Percent(100.0)),
-                    min_size: Size::new(Val::Px(800.0), Val::Auto),
+                    // min_size: Size::new(Val::Px(400.0), Val::Auto),
+                    // max_size: Size::new(Val::Px(800.0), Val::Auto),
                     padding: UiRect::all(Val::Px(30.0)),
                     flex_direction: FlexDirection::ColumnReverse,
                     justify_content: JustifyContent::FlexStart,
@@ -118,7 +124,9 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 }));
                 // Paragraph
                 content.spawn_bundle(TextBundle::from_section(
-                    "Buttons are used to trigger actions. They can be clicked and hovered.",
+                    "Buttons are used to trigger actions. \
+                    They can be hovered and clicked. \
+                    The most basic button is the text button",
                     TextStyle {
                         font: fonts.p.clone(),
                         font_size: TEXT_FONT_SIZE,
@@ -140,79 +148,30 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                     color: COLOR_CONTENT_EXAMPLE.into(),
                     ..default()
                 }).with_children(| example_showcase | {
-                    // 1. Button without content
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            align_items: AlignItems::Center,
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    )).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            "Ok",
-                            TextStyle {
-                                font: fonts.p.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                    });
 
-                    // 2. Button with text
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            align_items: AlignItems::Center,
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    )).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            "Submit",
-                            TextStyle {
-                                font: fonts.p.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                    });
-
-                    // 3. Button with icon and text
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            align_items: AlignItems::Center,
-                            justify_content: JustifyContent::FlexStart,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    )).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            Icon::Delete.to_string(),
-                            TextStyle {
-                                font: fonts.icon.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ).with_style(Style {
-                            margin: UiRect::all(Val::Px(10.0)),
-                            ..default()
-                        }));
-                        button.spawn_bundle(TextBundle::from_section(
-                            "Delete",
-                            TextStyle {
-                                font: fonts.p.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                    });
+                    // Spawn text-buttons
+                    for text in ["Ok", "Submit", "Restart Game"] {
+                        example_showcase.spawn_bundle(
+                            ButtonWidgetBundle::new(Style {
+                                size: Size::new(Val::Auto, Val::Auto),
+                                padding: UiRect::new(Val::Px(25.0), Val::Px(25.0), Val::Px(10.0), Val::Px(10.0)),
+                                margin: UiRect::all(Val::Px(10.0)),
+                                align_items: AlignItems::Center,
+                                justify_content: JustifyContent::Center,
+                                ..default()
+                            }, 
+                            BUTTON_THEME
+                        )).with_children(| button | {
+                            button.spawn_bundle(TextBundle::from_section(
+                                text,
+                                TextStyle {
+                                    font: fonts.p.clone(),
+                                    font_size: BUTTON_FONT_SIZE,
+                                    color: COLOR_TEXT,
+                                }
+                            ));
+                        });
+                    }
                 });
 
                 // Title text
@@ -230,8 +189,8 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 // Paragraph
                 content.spawn_bundle(TextBundle::from_section(
                     "Buttons can be either enabled or disabled. \
-                            When they are disabled, they should look the part, \
-                            and not be able to be triggered by the user.",
+                            Disabled buttons should not be triggered by the user. \
+                            Buttons should clearly show when they are disabled by changing colors.",
                     TextStyle {
                         font: fonts.p.clone(),
                         font_size: TEXT_FONT_SIZE,
@@ -253,82 +212,31 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                     color: COLOR_CONTENT_EXAMPLE.into(),
                     ..default()
                 }).with_children(| example_showcase | {
-                    // 1. Button without content
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            align_items: AlignItems::Center,
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    ).with_enabled(false)
-                    ).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            "Ok",
-                            TextStyle {
-                                font: fonts.p.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                    });
 
-                    // 2. Button with text
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            align_items: AlignItems::Center,
-                            justify_content: JustifyContent::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    ).with_enabled(false)
-                    ).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            "Submit",
-                            TextStyle {
-                                font: fonts.p.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                    });
-
-                    // 3. Button with icon and text
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(150.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            align_items: AlignItems::Center,
-                            justify_content: JustifyContent::FlexStart,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    ).with_enabled(false)
-                    ).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            Icon::Wifi.to_string(),
-                            TextStyle {
-                                font: fonts.icon.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ).with_style(Style {
-                            margin: UiRect::all(Val::Px(10.0)),
-                            ..default()
-                        }));
-                        button.spawn_bundle(TextBundle::from_section(
-                            "Enable Wifi",
-                            TextStyle {
-                                font: fonts.p.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            }
-                        ));
-                    });
+                    // Spawn text-buttons
+                    for text in ["Ok", "Submit", "Restart Game"] {
+                        example_showcase.spawn_bundle(
+                            ButtonWidgetBundle::new(Style {
+                                size: Size::new(Val::Auto, Val::Auto),
+                                padding: UiRect::new(Val::Px(25.0), Val::Px(25.0), Val::Px(10.0), Val::Px(10.0)),
+                                margin: UiRect::all(Val::Px(10.0)),
+                                align_items: AlignItems::Center,
+                                justify_content: JustifyContent::Center,
+                                ..default()
+                            }, 
+                            BUTTON_THEME
+                        ).with_enabled(false)
+                        ).with_children(| button | {
+                            button.spawn_bundle(TextBundle::from_section(
+                                text,
+                                TextStyle {
+                                    font: fonts.p.clone(),
+                                    font_size: BUTTON_FONT_SIZE,
+                                    color: COLOR_TEXT,
+                                }
+                            ));
+                        });
+                    }
                 });
 
 
@@ -418,7 +326,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                             size: Size::new(Val::Px(150.0), Val::Px(40.0)),
                             margin: UiRect::all(Val::Px(10.0)),
                             align_items: AlignItems::Center,
-                            justify_content: JustifyContent::FlexStart,
+                            justify_content: JustifyContent::Center,
                             ..default()
                         }, 
                         BUTTON_THEME
@@ -428,13 +336,10 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                             Icon::Wifi.to_string(),
                             TextStyle {
                                 font: fonts.icon.clone(),
-                                font_size: BUTTON_FONT_SIZE,
+                                font_size: ICON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
-                        ).with_style(Style {
-                            margin: UiRect::all(Val::Px(10.0)),
-                            ..default()
-                        }));
+                        ));
                         button.spawn_bundle(TextBundle::from_section(
                             "Enable Wifi",
                             TextStyle {
@@ -483,122 +388,109 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                     color: COLOR_CONTENT_EXAMPLE.into(),
                     ..default()
                 }).with_children(| example_showcase | {
-                    // 1. Icon button
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            justify_content: JustifyContent::Center,
-                            align_items: AlignItems::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    )).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            Icon::Wifi.to_string(),
-                            TextStyle {
-                                font: fonts.icon.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            })
-                        );
-                    });
 
-                    // 2. Icon button
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            justify_content: JustifyContent::Center,
-                            align_items: AlignItems::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    )).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            Icon::Subtitles.to_string(),
-                            TextStyle {
-                                font: fonts.icon.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            })
-                        );
-                    });
-
-                    // 3. Icon button
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            justify_content: JustifyContent::Center,
-                            align_items: AlignItems::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    )).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            Icon::Delete.to_string(),
-                            TextStyle {
-                                font: fonts.icon.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            })
-                        );
-                    });
-
-                    // 3. Icon button
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            justify_content: JustifyContent::Center,
-                            align_items: AlignItems::Center,
-                            ..default()
-                        }, 
-                        BUTTON_THEME
-                    )).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            Icon::AlarmAdd.to_string(),
-                            TextStyle {
-                                font: fonts.icon.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            })
-                        );
-                    });
-
-                    // 3. Icon button
-                    example_showcase.spawn_bundle(
-                        ButtonWidgetBundle::new(Style {
-                            size: Size::new(Val::Px(40.0), Val::Px(40.0)),
-                            margin: UiRect::all(Val::Px(10.0)),
-                            justify_content: JustifyContent::Center,
-                            align_items: AlignItems::Center,
-                            ..default()
-                        },
-                        BUTTON_THEME
-                    )).with_children(| button | {
-                        button.spawn_bundle(TextBundle::from_section(
-                            Icon::Camera.to_string(),
-                            TextStyle {
-                                font: fonts.icon.clone(),
-                                font_size: BUTTON_FONT_SIZE,
-                                color: COLOR_TEXT,
-                            })
-                        );
-                    });
+                    // Spawn icon-buttons
+                    for entry in [Icon::Wifi, Icon::Subtitles, Icon::Delete, Icon::Add, Icon::Home] {
+                        example_showcase.spawn_bundle(
+                            ButtonWidgetBundle::new(Style {
+                                size: Size::new(Val::Px(40.0), Val::Px(40.0)),
+                                margin: UiRect::all(Val::Px(10.0)),
+                                justify_content: JustifyContent::Center,
+                                align_items: AlignItems::Center,
+                                ..default()
+                            }, 
+                            BUTTON_THEME
+                        )).with_children(| button | {
+                            button.spawn_bundle(TextBundle::from_section(
+                                entry.to_string(),
+                                TextStyle {
+                                    font: fonts.icon.clone(),
+                                    font_size: ICON_FONT_SIZE,
+                                    color: COLOR_TEXT,
+                                })
+                            );
+                        });
+                    }
                 });
 
+                // Title text
+                content.spawn_bundle(TextBundle::from_section(
+                    "Icon and text buttons", 
+                    TextStyle {
+                        font: fonts.h1.clone(),
+                        font_size: H1_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ).with_style(Style {
+                    margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
+                   ..default()
+               }));
+                // Paragraph
+                content.spawn_bundle(TextBundle::from_section(
+                    "We can also create buttons that has both icons and text.",
+                    TextStyle {
+                        font: fonts.p.clone(),
+                        font_size: TEXT_FONT_SIZE,
+                        color: COLOR_TEXT,
+                    }
+                ));
+                
+                // Example Showcase
+                content.spawn_bundle(NodeBundle {
+                    style: Style {
+                        size: Size::new(Val::Percent(100.0), Val::Px(80.0)),
+                        margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(10.0), Val::Px(10.0)),
+                        flex_direction: FlexDirection::Row,
+                        align_items: AlignItems::Center,
+                        justify_content: JustifyContent::Center,
+                        
+                        ..default()
+                    },
+                    color: COLOR_CONTENT_EXAMPLE.into(),
+                    ..default()
+                }).with_children(| example_showcase | {
+
+                    // Spawn icon-buttons
+                    for (icon, text) in [
+                        (Icon::Wifi, "Enable Wifi"), 
+                        (Icon::Subtitles, "Toggle Subtitles"), 
+                        (Icon::Delete, "Delete Item"), 
+                        (Icon::Add, "Add item"), 
+                        (Icon::Home, "Home")
+                    ] {
+                        example_showcase.spawn_bundle(
+                            ButtonWidgetBundle::new(Style {
+                                size: Size::new(Val::Auto, Val::Auto),
+                                padding: UiRect::new(Val::Px(15.0), Val::Px(15.0), Val::Px(10.0), Val::Px(10.0)),
+                                margin: UiRect::all(Val::Px(3.0)),
+                                align_items: AlignItems::Center,
+                                justify_content: JustifyContent::Center,
+                                ..default()
+                            }, 
+                            BUTTON_THEME
+                        )).with_children(| button | {
+                            button.spawn_bundle(TextBundle::from_section(
+                                icon.to_string(),
+                                TextStyle {
+                                    font: fonts.icon.clone(),
+                                    font_size: ICON_FONT_SIZE,
+                                    color: COLOR_TEXT,
+                                }
+                            ).with_style(Style {
+                                margin: UiRect::new(Val::Undefined, Val::Px(5.0), Val::Undefined, Val::Undefined),
+                                ..default()
+                            }));
+                            button.spawn_bundle(TextBundle::from_section(
+                                text,
+                                TextStyle {
+                                    font: fonts.p.clone(),
+                                    font_size: BUTTON_FONT_SIZE,
+                                    color: COLOR_TEXT,
+                                }
+                            ));
+                        });
+                    }
+                });
             });
         });
 }
-
-// Handling clicks
-// Upload file button
-// Button with icon and label
-
-// All buttons should showcase
-// Hover visual behaviour
-// Button click visuals
-// Button disabled visuals
-//

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, ecs::system::Resource};
 use bevy_widgets::{
     widget::button::{ButtonColor, ButtonTheme, ButtonWidgetBundle, TriggerPolicy},
     WidgetPlugin,
@@ -20,15 +20,17 @@ const COLOR_CONTENT_EXAMPLE: Color = Color::rgb(0.055, 0.12, 0.19);
 
 const PRIMARY: Color = Color::rgb(0.2274, 0.2, 0.2078);
 // const COLOR_CONTENT_BACKGROUND: Color = Color::hsl(224, 15, 39);
-const H1_FONT: &str = "fonts/Roboto/Roboto-Bold.ttf";
 const H1_FONT_SIZE: f32 = 30.0;
 const COLOR_TEXT: Color = Color::rgb(0.905, 0.921, 0.941);
 
+const H1_FONT: &str = "fonts/Roboto/Roboto-Bold.ttf";
 const TEXT_FONT: &str = "fonts/Roboto/Roboto-Regular.ttf";
+const MATERIAL_FONT: &str = "fonts/MaterialIcons-Regular.ttf";
+
+
 const TEXT_FONT_SIZE: f32 = 18.0;
 const BUTTON_FONT_SIZE: f32 = 20.0;
 
-const MATERIAL_FONT: &str = "fonts/MaterialIcons-Regular.ttf";
 
 const BUTTON_THEME: ButtonTheme = ButtonTheme {
     background_enabled: ButtonColor {
@@ -57,15 +59,26 @@ const BUTTON_THEME: ButtonTheme = ButtonTheme {
     },
 };
 
+struct Fonts {
+    h1: Handle<Font>,
+    p: Handle<Font>,
+    icon: Handle<Font>
+}
+
 /// Camera
 fn setup_camera(mut cmd: Commands) {
     cmd.spawn_bundle(Camera2dBundle::default());
 }
 
-// Button can be interacted with
-// It has some content
-// That content is either an icon, some text or both
+
 fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
+    // Fonts
+    let fonts = Fonts {
+        h1: asset_server.load(H1_FONT),
+        p: asset_server.load(TEXT_FONT),
+        icon: asset_server.load(MATERIAL_FONT),
+    };
+
     // root node
     cmd.spawn_bundle(NodeBundle {
             style: Style {
@@ -95,7 +108,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 content.spawn_bundle(TextBundle::from_section(
                     "Buttons", 
                     TextStyle {
-                        font: asset_server.load(H1_FONT).into(),
+                        font: fonts.h1.clone(),
                         font_size: H1_FONT_SIZE,
                         color: COLOR_TEXT,
                     }
@@ -107,7 +120,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 content.spawn_bundle(TextBundle::from_section(
                     "Buttons are used to trigger actions. They can be clicked and hovered.",
                     TextStyle {
-                        font: asset_server.load(TEXT_FONT).into(),
+                        font: fonts.p.clone(),
                         font_size: TEXT_FONT_SIZE,
                         color: COLOR_TEXT,
                     }
@@ -141,7 +154,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             "Ok",
                             TextStyle {
-                                font: asset_server.load(TEXT_FONT).into(),
+                                font: fonts.p.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -162,7 +175,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             "Submit",
                             TextStyle {
-                                font: asset_server.load(TEXT_FONT).into(),
+                                font: fonts.p.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -183,7 +196,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             Icon::Delete.to_string(),
                             TextStyle {
-                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font: fonts.icon.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -194,7 +207,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             "Delete",
                             TextStyle {
-                                font: asset_server.load(TEXT_FONT).into(),
+                                font: fonts.p.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -206,7 +219,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 content.spawn_bundle(TextBundle::from_section(
                     "Disabled Buttons", 
                     TextStyle {
-                        font: asset_server.load(H1_FONT).into(),
+                        font: fonts.h1.clone(),
                         font_size: H1_FONT_SIZE,
                         color: COLOR_TEXT,
                     }
@@ -220,7 +233,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                             When they are disabled, they should look the part, \
                             and not be able to be triggered by the user.",
                     TextStyle {
-                        font: asset_server.load(TEXT_FONT).into(),
+                        font: fonts.p.clone(),
                         font_size: TEXT_FONT_SIZE,
                         color: COLOR_TEXT,
                     }
@@ -255,7 +268,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             "Ok",
                             TextStyle {
-                                font: asset_server.load(TEXT_FONT).into(),
+                                font: fonts.p.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -277,7 +290,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             "Submit",
                             TextStyle {
-                                font: asset_server.load(TEXT_FONT).into(),
+                                font: fonts.p.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -299,7 +312,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             Icon::Wifi.to_string(),
                             TextStyle {
-                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font: fonts.icon.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -310,7 +323,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             "Enable Wifi",
                             TextStyle {
-                                font: asset_server.load(TEXT_FONT).into(),
+                                font: fonts.p.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -323,7 +336,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 content.spawn_bundle(TextBundle::from_section(
                     "Trigger Policy", 
                     TextStyle {
-                        font: asset_server.load(H1_FONT).into(),
+                        font: fonts.h1.clone(),
                         font_size: H1_FONT_SIZE,
                         color: COLOR_TEXT,
                     }
@@ -335,7 +348,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 content.spawn_bundle(TextBundle::from_section(
                     "Buttons are triggered on release by default. By setting the trigger-policy you can change the button to trigger on press instead.",
                     TextStyle {
-                        font: asset_server.load(TEXT_FONT).into(),
+                        font: fonts.p.clone(),
                         font_size: TEXT_FONT_SIZE,
                         color: COLOR_TEXT,
                     }
@@ -370,7 +383,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             "Ok",
                             TextStyle {
-                                font: asset_server.load(TEXT_FONT).into(),
+                                font: fonts.p.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -392,7 +405,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             "Submit",
                             TextStyle {
-                                font: asset_server.load(TEXT_FONT).into(),
+                                font: fonts.p.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -414,7 +427,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             Icon::Wifi.to_string(),
                             TextStyle {
-                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font: fonts.icon.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -425,7 +438,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             "Enable Wifi",
                             TextStyle {
-                                font: asset_server.load(TEXT_FONT).into(),
+                                font: fonts.p.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             }
@@ -438,7 +451,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 content.spawn_bundle(TextBundle::from_section(
                     "Icon Buttons", 
                     TextStyle {
-                        font: asset_server.load(H1_FONT).into(),
+                        font: fonts.h1.clone(),
                         font_size: H1_FONT_SIZE,
                         color: COLOR_TEXT,
                     }
@@ -450,7 +463,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                 content.spawn_bundle(TextBundle::from_section(
                     "Some buttons only need icon.",
                     TextStyle {
-                        font: asset_server.load(TEXT_FONT).into(),
+                        font: fonts.p.clone(),
                         font_size: TEXT_FONT_SIZE,
                         color: COLOR_TEXT,
                     }
@@ -484,7 +497,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             Icon::Wifi.to_string(),
                             TextStyle {
-                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font: fonts.icon.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             })
@@ -505,7 +518,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             Icon::Subtitles.to_string(),
                             TextStyle {
-                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font: fonts.icon.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             })
@@ -526,7 +539,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             Icon::Delete.to_string(),
                             TextStyle {
-                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font: fonts.icon.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             })
@@ -547,7 +560,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             Icon::AlarmAdd.to_string(),
                             TextStyle {
-                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font: fonts.icon.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             })
@@ -568,7 +581,7 @@ fn setup_page(mut cmd: Commands, asset_server: Res<AssetServer>) {
                         button.spawn_bundle(TextBundle::from_section(
                             Icon::Camera.to_string(),
                             TextStyle {
-                                font: asset_server.load(MATERIAL_FONT).into(),
+                                font: fonts.icon.clone(),
                                 font_size: BUTTON_FONT_SIZE,
                                 color: COLOR_TEXT,
                             })

--- a/src/content_builder.rs
+++ b/src/content_builder.rs
@@ -1,7 +1,7 @@
-use bevy::{prelude::{ChildBuilder, default, BuildChildren, TextBundle}, ui::{Size, UiRect, Style, Val, AlignItems, JustifyContent}};
+use bevy::{prelude::{ChildBuilder, default, BuildChildren, TextBundle}, ui::{Size, UiRect, Style, Val, AlignItems, JustifyContent, FocusPolicy}};
 use material_icons::Icon;
 
-use crate::{widget::button::ButtonWidgetBundle, theme::WidgetTheme};
+use crate::{widget::button::{ButtonWidgetBundle, TriggerPolicy}, theme::WidgetTheme};
 
 /// Creates a new H1 title
 pub fn create_h1(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str) {
@@ -18,7 +18,7 @@ pub fn create_p(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str) {
 }
 
 /// Creates a new Text Button Widget
-pub fn create_text_button(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str) {
+pub fn create_text_button(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str, enabled: bool, policy: TriggerPolicy) {
     container.spawn_bundle(
         ButtonWidgetBundle::new(Style {
             size: Size::new(Val::Auto, Val::Auto),
@@ -29,13 +29,14 @@ pub fn create_text_button(container: &mut ChildBuilder, theme: &WidgetTheme, tex
             ..default()
         }, 
         theme.button_theme.clone()
-    )).with_children(| button | {
+    ).with_enabled(enabled).with_policy(policy)
+    ).with_children(| button | {
         button.spawn_bundle(TextBundle::from_section(text,theme.widget.clone()));
     });
 }
 
 /// Creates a new icon-button widget
-pub fn create_icon_button(container: &mut ChildBuilder, theme: &WidgetTheme, icon: Icon) {
+pub fn create_icon_button(container: &mut ChildBuilder, theme: &WidgetTheme, icon: Icon, enabled: bool, policy: TriggerPolicy) {
     container.spawn_bundle(
         ButtonWidgetBundle::new(Style {
             size: Size::new(Val::Auto, Val::Auto),
@@ -46,13 +47,14 @@ pub fn create_icon_button(container: &mut ChildBuilder, theme: &WidgetTheme, ico
             ..default()
         }, 
         theme.button_theme.clone()
-    )).with_children(| button | {
+    ).with_enabled(enabled).with_policy(policy)
+    ).with_children(| button | {
         button.spawn_bundle(TextBundle::from_section(icon.to_string(), theme.icon.clone()));
     });
 }
 
 /// Creates a new button with icon and text
-pub fn create_label_button(container: &mut ChildBuilder, theme: &WidgetTheme, icon: Icon, text: &str) {
+pub fn create_label_button(container: &mut ChildBuilder, theme: &WidgetTheme, icon: Icon, text: &str, enabled: bool, policy: TriggerPolicy) {
     container.spawn_bundle(
         ButtonWidgetBundle::new(Style {
             size: Size::new(Val::Auto, Val::Auto),
@@ -63,7 +65,8 @@ pub fn create_label_button(container: &mut ChildBuilder, theme: &WidgetTheme, ic
             ..default()
         }, 
         theme.button_theme.clone()
-    )).with_children(| button | {
+    ).with_enabled(enabled).with_policy(policy)
+    ).with_children(| button | {
         button.spawn_bundle(
             TextBundle::from_section(icon.to_string(), theme.icon.clone())
                 .with_style(Style {

--- a/src/content_builder.rs
+++ b/src/content_builder.rs
@@ -1,15 +1,27 @@
-use bevy::{prelude::{ChildBuilder, default, BuildChildren, TextBundle}, ui::{Size, UiRect, Style, Val, AlignItems, JustifyContent, FocusPolicy}};
+use bevy::{
+    prelude::{default, BuildChildren, ChildBuilder, TextBundle},
+    ui::{AlignItems, JustifyContent, Size, Style, UiRect, Val},
+};
 use material_icons::Icon;
 
-use crate::{widget::button::{ButtonWidgetBundle, TriggerPolicy}, theme::WidgetTheme};
+use crate::{
+    theme::WidgetTheme,
+    widget::button::{ButtonWidgetBundle, TriggerPolicy},
+};
 
 /// Creates a new H1 title
 pub fn create_h1(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str) {
-    container.spawn_bundle(TextBundle::from_section(text, theme.h1.clone())
-    .with_style(Style {
-        margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
-       ..default()
-   }));
+    container.spawn_bundle(
+        TextBundle::from_section(text, theme.h1.clone()).with_style(Style {
+            margin: UiRect::new(
+                Val::Undefined,
+                Val::Undefined,
+                Val::Px(15.0),
+                Val::Undefined,
+            ),
+            ..default()
+        }),
+    );
 }
 
 /// Create a new paragraph section
@@ -18,62 +30,118 @@ pub fn create_p(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str) {
 }
 
 /// Creates a new Text Button Widget
-pub fn create_text_button(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str, enabled: bool, policy: TriggerPolicy) {
-    container.spawn_bundle(
-        ButtonWidgetBundle::new(Style {
-            size: Size::new(Val::Auto, Val::Auto),
-            padding: UiRect::new(Val::Px(15.0), Val::Px(15.0), Val::Px(10.0), Val::Px(10.0)),
-            margin: UiRect::all(Val::Px(4.0)),
-            align_items: AlignItems::Center,
-            justify_content: JustifyContent::Center,
-            ..default()
-        }, 
-        theme.button_theme.clone()
-    ).with_enabled(enabled).with_policy(policy)
-    ).with_children(| button | {
-        button.spawn_bundle(TextBundle::from_section(text,theme.widget.clone()));
-    });
+pub fn create_text_button(
+    container: &mut ChildBuilder,
+    theme: &WidgetTheme,
+    text: &str,
+    enabled: bool,
+    policy: TriggerPolicy,
+) {
+    container
+        .spawn_bundle(
+            ButtonWidgetBundle::new(
+                Style {
+                    size: Size::new(Val::Auto, Val::Auto),
+                    padding: UiRect::new(
+                        Val::Px(15.0),
+                        Val::Px(15.0),
+                        Val::Px(10.0),
+                        Val::Px(10.0),
+                    ),
+                    margin: UiRect::all(Val::Px(4.0)),
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Center,
+                    ..default()
+                },
+                theme.button_theme.clone(),
+            )
+            .with_enabled(enabled)
+            .with_policy(policy),
+        )
+        .with_children(|button| {
+            button.spawn_bundle(TextBundle::from_section(text, theme.widget.clone()));
+        });
 }
 
 /// Creates a new icon-button widget
-pub fn create_icon_button(container: &mut ChildBuilder, theme: &WidgetTheme, icon: Icon, enabled: bool, policy: TriggerPolicy) {
-    container.spawn_bundle(
-        ButtonWidgetBundle::new(Style {
-            size: Size::new(Val::Auto, Val::Auto),
-            padding: UiRect::new(Val::Px(15.0), Val::Px(15.0), Val::Px(10.0), Val::Px(10.0)),
-            margin: UiRect::all(Val::Px(4.0)),
-            justify_content: JustifyContent::Center,
-            align_items: AlignItems::Center,
-            ..default()
-        }, 
-        theme.button_theme.clone()
-    ).with_enabled(enabled).with_policy(policy)
-    ).with_children(| button | {
-        button.spawn_bundle(TextBundle::from_section(icon.to_string(), theme.icon.clone()));
-    });
+pub fn create_icon_button(
+    container: &mut ChildBuilder,
+    theme: &WidgetTheme,
+    icon: Icon,
+    enabled: bool,
+    policy: TriggerPolicy,
+) {
+    container
+        .spawn_bundle(
+            ButtonWidgetBundle::new(
+                Style {
+                    size: Size::new(Val::Auto, Val::Auto),
+                    padding: UiRect::new(
+                        Val::Px(15.0),
+                        Val::Px(15.0),
+                        Val::Px(10.0),
+                        Val::Px(10.0),
+                    ),
+                    margin: UiRect::all(Val::Px(4.0)),
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::Center,
+                    ..default()
+                },
+                theme.button_theme.clone(),
+            )
+            .with_enabled(enabled)
+            .with_policy(policy),
+        )
+        .with_children(|button| {
+            button.spawn_bundle(TextBundle::from_section(
+                icon.to_string(),
+                theme.icon.clone(),
+            ));
+        });
 }
 
 /// Creates a new button with icon and text
-pub fn create_label_button(container: &mut ChildBuilder, theme: &WidgetTheme, icon: Icon, text: &str, enabled: bool, policy: TriggerPolicy) {
-    container.spawn_bundle(
-        ButtonWidgetBundle::new(Style {
-            size: Size::new(Val::Auto, Val::Auto),
-            padding: UiRect::new(Val::Px(15.0), Val::Px(15.0), Val::Px(10.0), Val::Px(10.0)),
-            margin: UiRect::all(Val::Px(4.0)),
-            align_items: AlignItems::Center,
-            justify_content: JustifyContent::Center,
-            ..default()
-        }, 
-        theme.button_theme.clone()
-    ).with_enabled(enabled).with_policy(policy)
-    ).with_children(| button | {
-        button.spawn_bundle(
-            TextBundle::from_section(icon.to_string(), theme.icon.clone())
-                .with_style(Style {
-                    margin: UiRect::new(Val::Undefined, Val::Px(5.0), Val::Undefined, Val::Undefined),
+pub fn create_label_button(
+    container: &mut ChildBuilder,
+    theme: &WidgetTheme,
+    icon: Icon,
+    text: &str,
+    enabled: bool,
+    policy: TriggerPolicy,
+) {
+    container
+        .spawn_bundle(
+            ButtonWidgetBundle::new(
+                Style {
+                    size: Size::new(Val::Auto, Val::Auto),
+                    padding: UiRect::new(
+                        Val::Px(15.0),
+                        Val::Px(15.0),
+                        Val::Px(10.0),
+                        Val::Px(10.0),
+                    ),
+                    margin: UiRect::all(Val::Px(4.0)),
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Center,
                     ..default()
-                })
-        );
-        button.spawn_bundle(TextBundle::from_section(text,theme.widget.clone()));
-    });
+                },
+                theme.button_theme.clone(),
+            )
+            .with_enabled(enabled)
+            .with_policy(policy),
+        )
+        .with_children(|button| {
+            button.spawn_bundle(
+                TextBundle::from_section(icon.to_string(), theme.icon.clone()).with_style(Style {
+                    margin: UiRect::new(
+                        Val::Undefined,
+                        Val::Px(5.0),
+                        Val::Undefined,
+                        Val::Undefined,
+                    ),
+                    ..default()
+                }),
+            );
+            button.spawn_bundle(TextBundle::from_section(text, theme.widget.clone()));
+        });
 }

--- a/src/content_builder.rs
+++ b/src/content_builder.rs
@@ -1,0 +1,76 @@
+use bevy::{prelude::{ChildBuilder, default, BuildChildren, TextBundle}, ui::{Size, UiRect, Style, Val, AlignItems, JustifyContent}};
+use material_icons::Icon;
+
+use crate::{widget::button::ButtonWidgetBundle, theme::WidgetTheme};
+
+/// Creates a new H1 title
+pub fn create_h1(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str) {
+    container.spawn_bundle(TextBundle::from_section(text, theme.h1.clone())
+    .with_style(Style {
+        margin: UiRect::new(Val::Undefined, Val::Undefined, Val::Px(15.0), Val::Undefined),
+       ..default()
+   }));
+}
+
+/// Create a new paragraph section
+pub fn create_p(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str) {
+    container.spawn_bundle(TextBundle::from_section(text, theme.p.clone()));
+}
+
+/// Creates a new Text Button Widget
+pub fn create_text_button(container: &mut ChildBuilder, theme: &WidgetTheme, text: &str) {
+    container.spawn_bundle(
+        ButtonWidgetBundle::new(Style {
+            size: Size::new(Val::Auto, Val::Auto),
+            padding: UiRect::new(Val::Px(15.0), Val::Px(15.0), Val::Px(10.0), Val::Px(10.0)),
+            margin: UiRect::all(Val::Px(4.0)),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            ..default()
+        }, 
+        theme.button_theme.clone()
+    )).with_children(| button | {
+        button.spawn_bundle(TextBundle::from_section(text,theme.widget.clone()));
+    });
+}
+
+/// Creates a new icon-button widget
+pub fn create_icon_button(container: &mut ChildBuilder, theme: &WidgetTheme, icon: Icon) {
+    container.spawn_bundle(
+        ButtonWidgetBundle::new(Style {
+            size: Size::new(Val::Auto, Val::Auto),
+            padding: UiRect::new(Val::Px(15.0), Val::Px(15.0), Val::Px(10.0), Val::Px(10.0)),
+            margin: UiRect::all(Val::Px(4.0)),
+            justify_content: JustifyContent::Center,
+            align_items: AlignItems::Center,
+            ..default()
+        }, 
+        theme.button_theme.clone()
+    )).with_children(| button | {
+        button.spawn_bundle(TextBundle::from_section(icon.to_string(), theme.icon.clone()));
+    });
+}
+
+/// Creates a new button with icon and text
+pub fn create_label_button(container: &mut ChildBuilder, theme: &WidgetTheme, icon: Icon, text: &str) {
+    container.spawn_bundle(
+        ButtonWidgetBundle::new(Style {
+            size: Size::new(Val::Auto, Val::Auto),
+            padding: UiRect::new(Val::Px(15.0), Val::Px(15.0), Val::Px(10.0), Val::Px(10.0)),
+            margin: UiRect::all(Val::Px(4.0)),
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            ..default()
+        }, 
+        theme.button_theme.clone()
+    )).with_children(| button | {
+        button.spawn_bundle(
+            TextBundle::from_section(icon.to_string(), theme.icon.clone())
+                .with_style(Style {
+                    margin: UiRect::new(Val::Undefined, Val::Px(5.0), Val::Undefined, Val::Undefined),
+                    ..default()
+                })
+        );
+        button.spawn_bundle(TextBundle::from_section(text,theme.widget.clone()));
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,13 @@ use system::{setup_resources, toggle_system, update_checkbox, update_radio, upda
 mod entity;
 mod system;
 pub mod widget;
+pub mod content_builder;
+pub mod theme;
 
 pub use entity::*;
 pub use system::*;
+pub use content_builder::*;
+
 use widget::button::{
     button_color, button_interaction, button_trigger, on_button_trigger, ButtonEvent,
     PrevInteraction,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,18 +8,31 @@ mod entity;
 mod system;
 pub mod widget;
 
+pub use entity::*;
+pub use system::*;
+use widget::button::{
+    button_color, button_interaction, button_trigger, on_button_trigger, ButtonEvent,
+    PrevInteraction,
+};
+
 // Widgetplugin should be the collector of all the widget systems
 pub struct WidgetPlugin;
 
 impl Plugin for WidgetPlugin {
     fn build(&self, app: &mut App) {
         // Systems
-        app.add_startup_system(setup_resources)
-            .add_system(button_output)
+        app.add_event::<ButtonEvent>()
+            .add_startup_system(setup_resources)
+            // .add_system(button_output)
             .add_system(toggle_system)
+            .add_system(button_color)
+            .add_system(button_interaction)
+            .add_system(button_trigger.after(button_interaction))
+            .add_system(on_button_trigger.after(button_trigger))
             .add_system(update_checkbox.after(toggle_system))
             .add_system(update_radio.after(toggle_system))
-            .add_system(update_widget_colors);
+            .add_system(update_widget_colors)
+            .add_system(update_checkbox_colors);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ impl Plugin for WidgetPlugin {
         // Systems
         app.add_event::<ButtonEvent>()
             .add_startup_system(setup_resources)
-            // .add_system(button_output)
+            .add_system(button_output)
             .add_system(toggle_system)
             .add_system(button_color)
             .add_system(button_interaction)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,19 +4,18 @@ use bevy::{
 };
 use system::{setup_resources, toggle_system, update_checkbox, update_radio, update_widget_colors};
 
+pub mod content_builder;
 mod entity;
 mod system;
-pub mod widget;
-pub mod content_builder;
 pub mod theme;
+pub mod widget;
 
+pub use content_builder::*;
 pub use entity::*;
 pub use system::*;
-pub use content_builder::*;
 
 use widget::button::{
     button_color, button_interaction, button_trigger, on_button_trigger, ButtonEvent,
-    PrevInteraction,
 };
 
 // Widgetplugin should be the collector of all the widget systems
@@ -35,8 +34,8 @@ impl Plugin for WidgetPlugin {
             .add_system(on_button_trigger.after(button_trigger))
             .add_system(update_checkbox.after(toggle_system))
             .add_system(update_radio.after(toggle_system))
-            .add_system(update_widget_colors)
-            .add_system(update_checkbox_colors);
+            .add_system(update_widget_colors);
+        // .add_system(update_checkbox_colors);
     }
 }
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,14 @@
+use bevy::text::TextStyle;
+
+use crate::widget::button::ButtonTheme;
+
+// This is a stopgap solution until a more complete and sensible theming-system can be figured out
+pub struct WidgetTheme {
+    // Whatever fonts we need
+    pub h1: TextStyle,
+    pub p: TextStyle,
+    pub icon: TextStyle,
+    pub widget: TextStyle,
+    // Whatever colors we need
+    pub button_theme: ButtonTheme
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -10,5 +10,5 @@ pub struct WidgetTheme {
     pub icon: TextStyle,
     pub widget: TextStyle,
     // Whatever colors we need
-    pub button_theme: ButtonTheme
+    pub button_theme: ButtonTheme,
 }

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -1,0 +1,234 @@
+use std::process::Child;
+
+use bevy::{
+    prelude::{
+        default, info, AnyOf, Bundle, Button, Changed, Children, Color, Component, Entity,
+        EventReader, EventWriter, NodeBundle, Or, Query, With,
+    },
+    text::Text,
+    ui::{Interaction, Style, UiColor},
+};
+
+/// Event that a button has triggered
+pub struct ButtonEvent(Entity);
+
+/// Marker component for a ButtonWidget
+#[derive(Component, Default, Clone, Debug)]
+pub struct ButtonWidget;
+
+/// State for user interaction with the button
+#[derive(Component, Default, Clone, Copy, Debug)]
+pub enum ButtonState {
+    Pressed,
+    Released,
+    Hovered,
+    #[default]
+    None,
+}
+
+/// Determines if user can interact with button at all
+#[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+pub enum ButtonEnabledState {
+    #[default]
+    Enabled,
+    Disabled,
+}
+
+#[derive(Component, Default, Clone, Copy, Debug)]
+pub enum TriggerPolicy {
+    #[default]
+    OnRelease,
+    OnPress,
+}
+
+#[derive(Component, Clone, Debug, Default)]
+pub struct PrevInteraction(Interaction);
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ButtonColor {
+    pub pressed: Color,
+    pub released: Color,
+    pub hovered: Color,
+    pub default: Color,
+}
+
+#[derive(Component, Clone, Debug, Default)]
+pub struct ButtonTheme {
+    pub background_enabled: ButtonColor,
+    pub background_disabled: ButtonColor,
+    pub foreground_enabled: ButtonColor,
+    pub foreground_disabled: ButtonColor,
+}
+
+/// A Button Widget
+#[derive(Bundle, Clone, Debug, Default)]
+pub struct ButtonWidgetBundle {
+    #[bundle]
+    pub node_bundle: NodeBundle,
+    /// Enables clicking on the widget
+    pub button: Button,
+    /// Interaction state of the widget
+    pub interaction: Interaction,
+    /// Tracks the last known interaction
+    pub prev_interaction: PrevInteraction,
+    /// Marker component
+    pub widget: ButtonWidget,
+    pub state: ButtonState,
+    pub policy: TriggerPolicy,
+    pub enabled: ButtonEnabledState,
+    pub theme: ButtonTheme,
+}
+
+impl ButtonWidgetBundle {
+    pub fn new(style: Style, theme: ButtonTheme) -> Self {
+        ButtonWidgetBundle {
+            node_bundle: NodeBundle {
+                style,
+                color: UiColor(theme.background_enabled.default.into()),
+                ..default()
+            },
+            theme,
+            ..default()
+        }
+    }
+
+    pub fn with_policy(mut self, policy: TriggerPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+    pub fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = if enabled {
+            ButtonEnabledState::Enabled
+        } else {
+            ButtonEnabledState::Disabled
+        };
+        self
+    }
+    pub fn with_theme(mut self, theme: ButtonTheme) -> Self {
+        self.theme = theme;
+        self
+    }
+}
+
+/// Responsible for triggering the button event if the player interacts with the button
+pub(crate) fn button_trigger(
+    q: Query<
+        (Entity, &ButtonState, &TriggerPolicy, &ButtonEnabledState),
+        (With<ButtonWidget>, Changed<ButtonState>),
+    >,
+    mut trigger: EventWriter<ButtonEvent>,
+) {
+    for (button, state, policy, enabled) in &q {
+        // Should not be allowed to trigger a button that is disabled
+        if *enabled == ButtonEnabledState::Disabled {
+            continue;
+        }
+
+        match (*state, *policy) {
+            (ButtonState::Pressed, TriggerPolicy::OnPress) => {
+                trigger.send(ButtonEvent(button));
+            }
+            (ButtonState::Released, TriggerPolicy::OnRelease) => {
+                trigger.send(ButtonEvent(button));
+            }
+            _ => {}
+        }
+    }
+}
+
+pub(crate) fn button_color(
+    mut q: Query<
+        (
+            &mut UiColor,
+            &ButtonState,
+            &ButtonEnabledState,
+            &ButtonTheme,
+            Option<&Children>,
+        ),
+        (
+            With<ButtonWidget>,
+            AnyOf<(
+                Changed<ButtonState>,
+                Changed<ButtonEnabledState>,
+                Changed<ButtonTheme>,
+            )>,
+        ),
+    >,
+    mut content: Query<&mut Text>,
+) {
+    for (mut color, state, enabled, button_theme, children) in &mut q {
+        let (background_theme, foreground_theme) = match enabled {
+            ButtonEnabledState::Enabled => (
+                &button_theme.background_enabled,
+                &button_theme.foreground_enabled,
+            ),
+            ButtonEnabledState::Disabled => (
+                &button_theme.background_disabled,
+                &button_theme.foreground_disabled,
+            ),
+        };
+
+        color.0 = match *state {
+            ButtonState::Pressed => background_theme.pressed,
+            ButtonState::Released => background_theme.released,
+            ButtonState::Hovered => background_theme.hovered,
+            ButtonState::None => background_theme.default,
+        };
+
+        if children.is_none() {
+            continue;
+        }
+
+        for child in children.unwrap() {
+            if let Ok(mut text) = content.get_mut(*child) {
+                for section in text.sections.iter_mut() {
+                    section.style.color = match *state {
+                        ButtonState::Pressed => foreground_theme.pressed,
+                        ButtonState::Released => foreground_theme.released,
+                        ButtonState::Hovered => foreground_theme.hovered,
+                        ButtonState::None => foreground_theme.default,
+                    }
+                }
+            }
+        }
+
+        //                 color.0 = match *state {
+        //     ButtonState::Pressed => Color::hsla(1., 1., 1.0, 0.1),
+        //     ButtonState::Released => Color::hsla(195., 1., 1.0, 0.1),
+        //     ButtonState::Hovered => Color::hsla(1., 1., 1.0, 0.03),
+        //     ButtonState::None => Color::hsla(0.0, 0.0, 0.0, 0.0),
+        // }
+    }
+}
+
+pub(crate) fn on_button_trigger(mut reader: EventReader<ButtonEvent>) {
+    for event in &mut reader.iter() {
+        // TOOD: Figure out how to ergonomically assign specific actions to specific game-play elements
+        info!("Button was triggered: {:?}", event.0);
+    }
+}
+
+// TODO: This need to clear the pressed state the next frame
+pub(crate) fn button_interaction(
+    mut changed: Query<
+        (&Interaction, &mut PrevInteraction, &mut ButtonState),
+        Or<(Changed<Interaction>, Changed<PrevInteraction>)>,
+    >,
+) {
+    for (new_state, mut prev_state, mut button_state) in &mut changed {
+        if prev_state.0 == Interaction::Clicked && *new_state == Interaction::Hovered {
+            *button_state = ButtonState::Released;
+        } else if prev_state.0 == Interaction::Hovered && *new_state == Interaction::Hovered {
+            *button_state = ButtonState::Hovered;
+        } else {
+            *button_state = match new_state {
+                Interaction::Clicked => ButtonState::Pressed,
+                Interaction::Hovered => ButtonState::Hovered,
+                Interaction::None => ButtonState::None,
+            }
+        }
+
+        // Cache the state for next frame
+        prev_state.0 = *new_state
+    }
+}

--- a/src/widget/button.rs
+++ b/src/widget/button.rs
@@ -191,13 +191,6 @@ pub(crate) fn button_color(
                 }
             }
         }
-
-        //                 color.0 = match *state {
-        //     ButtonState::Pressed => Color::hsla(1., 1., 1.0, 0.1),
-        //     ButtonState::Released => Color::hsla(195., 1., 1.0, 0.1),
-        //     ButtonState::Hovered => Color::hsla(1., 1., 1.0, 0.03),
-        //     ButtonState::None => Color::hsla(0.0, 0.0, 0.0, 0.0),
-        // }
     }
 }
 

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -1,2 +1,3 @@
+pub mod button;
 pub mod checkbox;
 pub mod radio;


### PR DESCRIPTION
Keep in mind that this is an early sketch, and will be improved upon. If you have ideas, I'm eager to hear them :)

## Features
- Button changes color on foreground and background according to `ButtonTheme`
- By setting the `TriggerPolicy`, user can choose if button should trigger `OnPress` or `OnRelease`
- Button can be either `enabled` or `disabled`
  - Button will never trigger when `disabled`
  - `ButtonTheme` will pick from disabled-themes

## Known issues
- `ButtonState::Released` interaction state is not reset back to `Hover` until the user moves the cursor out of the button